### PR TITLE
Dependencies level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+
+*.Rproj
+
+.Rbuildignore

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biomformat
-Version: 0.99.3
-Date: 2016-03-21
+Version: 0.99.4
+Date: 2016-04-16
 Maintainer: Paul J. McMurdie <mcmurdie@stanford.edu>
 License: GPL-2
 Title: An interface package for the BIOM file format

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biomformat
-Version: 0.99.2
-Date: 2015-10-07
+Version: 0.99.3
+Date: 2016-03-21
 Maintainer: Paul J. McMurdie <mcmurdie@stanford.edu>
 License: GPL-2
 Title: An interface package for the BIOM file format
@@ -15,7 +15,7 @@ Description: This is an R package for interfacing with the BIOM format. This pac
                  common core functions/methods.
 Imports: plyr (>= 1.8), jsonlite (>= 0.9.16), Matrix (>= 1.2), rhdf5
 Depends: R (>= 3.2), methods
-Suggests: testthat (>= 0.10), knitr (>= 1.3)
+Suggests: testthat (>= 0.10), knitr (>= 1.10), BiocStyle (>= 1.6), rmarkdown (>= 0.7)
 VignetteBuilder: knitr
 Collate: 'allClasses.R' 'allPackage.R' 'IO-methods.R' 'BIOM-class.R' 'validity-methods.R'
 biocViews: DataImport, Metagenomics, Microbiome

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,9 +13,9 @@ Description: This is an R package for interfacing with the BIOM format. This pac
                  back to a biom-format file. The design of this API is intended to match the python API and other tools included with the biom-format
                  project, but with a decidedly "R flavor" that should be familiar to R users. This includes S4 classes and methods, as well as extensions of
                  common core functions/methods.
-Imports: plyr (>= 1.8), jsonlite (>= 0.9.16), Matrix (>= 1.2), rhdf5
-Depends: R (>= 3.2), methods
-Suggests: testthat (>= 0.10), knitr (>= 1.10), BiocStyle (>= 1.6), rmarkdown (>= 0.7)
+Imports: plyr (>= 1.8), jsonlite (>= 0.9.16), Matrix (>= 1.1), rhdf5
+Depends: R (>= 3.1), methods
+Suggests: testthat (>= 0.10), knitr (>= 1.10), BiocStyle (>= 1.4), rmarkdown (>= 0.7)
 VignetteBuilder: knitr
 Collate: 'allClasses.R' 'allPackage.R' 'IO-methods.R' 'BIOM-class.R' 'validity-methods.R'
 biocViews: DataImport, Metagenomics, Microbiome

--- a/README.md
+++ b/README.md
@@ -13,29 +13,31 @@ The design of this API is intended to match the python API where appropriate, wh
 
 # Installation
 
-To install the latest stable release of the biom package enter the following in an R session (after official release).
+To install the latest stable release of the biomformat package enter the following in an R session (after official release).
 
 ```S
 source("http://bioconductor.org/biocLite.R")
-biocLite("biom")
+biocLite("biomformat")
 ```
 
 Before official release, or to install the latest development version, enter the following into an R session.
 
 ```S
 install.packages("devtools") # if not already installed
-devtools::install_github("biomformat", "joey711")
+devtools::install_github("joey711/biomformat")
 ```
 
 # Support
 
- * Please post feature or support requests and bugs at the [Issues Tracker for the biomformat package](https://github.com/joey711/biomformat/issues) on GitHub. Issues related to the format itself and not the R interface should be posted on the [issues tracker for the biom format](https://github.com/biom-format/biom-format/issues).
+ * Please post feature or support requests and bugs at the [Issues Tracker for the biomformat package](https://github.com/joey711/biomformat/issues) on GitHub.
+ Issues related to the format itself and not the R interface should be posted on the [issues tracker for the biom-format team](https://github.com/biocore/biom-format/issues).
  
  * Note that this is a separate (but friendly!) project from the biom-format team, and the software license is different between this package and much of the rest of the biom-format software, which has switched to BSD.
 
- * The official release version of this package will be submitted to Bioconductor project, where [the rhdf5 package](http://bioconductor.org/packages/release/bioc/html/rhdf5.html) lives. Other than that, CRAN would be a suitable destination.
+ * This package is scheduled for inclusion in the next stable release of the Bioconductor project (BioC).
+ BioC is also where [the rhdf5 package](http://bioconductor.org/packages/release/bioc/html/rhdf5.html) lives.
 
  * The original release of this package was [made available through CRAN](http://cran.r-project.org/web/packages/biom/index.html), 
  as the "biom" package, supporting version 1.x (JSON) only.
- The current plan is to let "biom" remain on CRAN in maintenance-only mode until "biomformat" is released on Bioconductor. At which point "biom" will be considered deprecated.
+ The current plan is to let "biom" remain on CRAN in maintenance-only mode until "biomformat" is released on Bioconductor. At which point "biom" will be considered deprecated, and eventually removed.
 

--- a/tests/testthat/test-IO.R
+++ b/tests/testthat/test-IO.R
@@ -66,6 +66,6 @@ test_that("imported biom files are S4", {
 })
 
 test_that("show method output tests",{
-	expect_output(x1, "biom object. \ntype:")
-	expect_output(x4, "biom object. \ntype:")
+	expect_output(print(x1), "biom object. \ntype:")
+	expect_output(print(x4), "biom object. \ntype:")
 })

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -22,8 +22,8 @@ x3 = read_biom(rich_dense_file)
 x4 = read_biom(rich_sparse_file)
 x5 = read_biom(rich_dense_char)
 x6 = read_biom(rich_sparse_char)
-x7 = read_biom(min_sparse_hdf5)
-x8 = read_biom(rich_sparse_hdf5)
+x7 = suppressWarnings(read_biom(min_sparse_hdf5))
+x8 = suppressWarnings(read_biom(rich_sparse_hdf5))
 
 
 # Test ncol, nrow, colnames, rownames

--- a/vignettes/biomformat.Rmd
+++ b/vignettes/biomformat.Rmd
@@ -1,12 +1,37 @@
-<!--
-%\VignetteEngine{knitr::knitr}
-%\VignetteIndexEntry{BIOM support in R main vignette}
--->
-`r library("knitr")`
-`r opts_chunk$set(cache=TRUE, fig.width=9)`
-<link href="http://joey711.github.com/phyloseq/markdown.css" rel="stylesheet"></link>
+---
+title: "Vignette TitleThe biomformat package Vignette"
+author: "Paul J. McMurdie"
+output: 
+  BiocStyle::html_document:
+    fig_height: 7
+    fig_width: 10
+    toc: yes
+    toc_depth: 2
+    number_sections: true
+vignette: >
+  %\VignetteIndexEntry{The biomformat package Vignette}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}  
+---
 
-# biomformat package for BIOM file format support in R
+`r library("knitr")`
+`r opts_chunk$set(cache=FALSE, fig.width=9, message=FALSE, warning=FALSE)`
+
+## Paul J. McMurdie & Joseph N. Paulson
+
+If you find *biomformat* and/or its tutorials useful, 
+please acknowledge and cite *biomformat* in your publications:
+
+Paul J. McMurdie and Joseph N Paulson (2015). *biomformat: An interface package for the BIOM file format.* R/Bioconductor package version 1.0.0. 
+
+
+## [phyloseq Home Page](https://github.com/joey711/biomformat/)
+
+phyloseq has many more utilities for interacting
+with this kind of data than are provided in this I/O-oriented package.
+
+
+## Motivation for the biomformat package
 
 This is an [R Markdown document](http://www.rstudio.com/ide/docs/r_markdown). Markdown is a simple formatting syntax for authoring web pages. Further details on [R markdown here](http://www.rstudio.com/ide/docs/r_markdown).
 
@@ -15,13 +40,14 @@ The BIOM file format (canonically pronounced "biome") is designed to be a genera
 This demo is designed to provide an overview of the biom package to get you started using it quickly. The biom package itself is intended to be a utility package that will be depended-upon by other packages in the future. It provides I/O functionality, and functions to make it easier to with data from biom-format files. It does not (and probably should not) provide statistical analysis functions. However, it does provide tools to access data from BIOM format files in ways that are extremely common in R (such as `"data.frame"`, `"matrix"`, and `"Matrix"` classes).
 
 **Package versions** at the time (`r date()`) of this build:
+
 ```{r packages}
 library("biomformat"); packageVersion("biomformat")
 ```
 
----
 
 # Read BIOM format
+
 Here is an example importing BIOM formats of different types into R using the `read_biom` function. The resulting data objects in R are given names beginning with `x`.
 
 ```{r read-biom-examples}
@@ -47,8 +73,6 @@ x1
 
 It would be hard to interpret and wasteful of RAM to stream all the data from a BIOM format file to the standard out when printed with `print` or `show` methods. Instead, a brief summary of the contents BIOM data is shown. 
 
-
----
 
 # Access BIOM data
 
@@ -104,8 +128,6 @@ boxplot(as(biom_data(x4), "vector"))
 heatmap(as(biom_data(x4), "matrix"))
 ```
 
-
----
 
 # Write BIOM format
 

--- a/vignettes/biomformat.Rmd
+++ b/vignettes/biomformat.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Vignette TitleThe biomformat package Vignette"
+title: "The biomformat package vignette"
 author: "Paul J. McMurdie"
 output: 
   BiocStyle::html_document:


### PR DESCRIPTION
Dear Paul McMurdie,
I am maintaining a shiny for metagenomic analysis (http://shaman.c3bi.pasteur.fr/) and we are blocked for the moment at R-3.1 version. The dependencies require R-3.2 with Matrix 1.2 and BiocStyle 1.6 for no reason. The package works really well with R-3.1, Matrix 1.1 and BiocStyle 1.4. All the biom that I have tested gave me the same result compared to an installation with R-3.3.1.
I will soon push these modifications on shaman.
Best,
Amine
